### PR TITLE
fix: update link to troubleshooting resource for Git

### DIFF
--- a/managing-files/version-control.md
+++ b/managing-files/version-control.md
@@ -33,4 +33,4 @@ $ git config --global user.email john@example.com
 
 ### Getting Out of Trouble
 
-Git can sometimes be a bit tricky. And we all eventually find ourselves in a place where we want to undo something or fix a mistake we made with Git. [This website](https://ohshitgit.com/) (pardon the profanity) has a bunch of really excellent solutions to common problems we sometimes run in to with Git.
+Git can sometimes be a bit tricky. And we all eventually find ourselves in a place where we want to undo something or fix a mistake we made with Git. [This website](https://dangitgit.com) contains a number of excellent solutions to common problems we sometimes run in to with Git.


### PR DESCRIPTION
This pull request updates a resource link in the documentation to provide a more appropriate reference for troubleshooting Git issues.

Documentation update:

* Updated the troubleshooting section in `managing-files/version-control.md` to link to `dangitgit.com` instead of `ohshitgit.com` for solutions to common Git problems.